### PR TITLE
added the option to use an image as swatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@ This extension will replace the default variant selection on PDP with an accordi
 ## Config
 - `horizontalInsets` (number) Horizontal insets for the characteristics in pixels (e.g. 16)
 - `bottomInset` (number) Trailing inset for the characteristics block in pixels (e.g. 16)
-- `animate` (boolean) Wether the characteristics accordions are supposed to be animated (_default_ `false`)
+- `animate` (boolean) Whether the characteristics accordions are supposed to be animated (_default_ `false`)
 - `characteristicBorderColor` (string) Border color of a characteristic section (e.g. `#57606a`)
-- `showBottomBorder` (boolean) Wether the last characteristic has a border at the bottom (_default_ `true`)
 - `characteristicValueBorderColor`(string) Border color of a characteristic value (e.g. `#57606a`)
 - `characteristicValueBorderColorSelected` (string) Border color of a selected characteristic value (e.g.`#0969da`)
-- `propertyWithColor` (string) An (additional) product property which contains a css color for a swatch.
-- `colorCharacteristic` (Array) A list of characteristic labels which are supposed to be displayed as swatches.
+- `showBottomBorder` (boolean) Whether the last characteristic has a border at the bottom (_default_ `true`)
+- `useImageAsSwatch` (boolean) Whether the swatch should be shown as an image (_default_ `false`)
+- `showSwatchAsCircle` (boolean) Whether the swatch is shown as a rectangle or a circle (_default_ `false`)
+- `showLabelBelowSwatch` (boolean) Whether the label of the swatch is shown below the swatch itself (_default_ `false`)
+- `imageOverlayLabelColor` (string) Text color of the optional image overlay label (_default_ `#fff`)
+- `propertyWithColor` (string) An (additional) product property which contains a css color for a swatch. (_default_ ``)
+- `colorCharacteristic` (Array) A list of characteristic names which are used as color swatch (e.g. ['Color', 'Shoe Color', 'Farbe'] (_default_ `null`)
 
 ## Classes
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This extension will replace the default variant selection on PDP with an accordi
 - `imageOverlayLabelColor` (string) Text color of the optional image overlay label (_default_ `#fff`)
 - `propertyWithColor` (string) An (additional) product property which contains a css color for a swatch. (_default_ ``)
 - `colorCharacteristic` (Array) A list of characteristic names which are used as color swatch (e.g. ['Color', 'Shoe Color', 'Farbe'] (_default_ `null`)
+- `imageSwatchSize` (number) The size of the image in pixel.
+- `imageSwatchBackgroundSize` (string) Defines how the image will be shown.V alue must be a property of CSS backgroundsize
 
 ## Classes
 

--- a/extension-config.json
+++ b/extension-config.json
@@ -128,6 +128,25 @@
         "type": "json",
         "required": true
       }
+    },
+    "imageSwatchSize": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": 50,
+      "params": {
+        "type": "number",
+        "label": "The size of the image in pixel."
+      }
+    },
+    "imageSwatchBackgroundSize": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": "cover",
+      "params": {
+        "label": "Value must be a property of CSS backgroundsize",
+        "type": "text",
+        "required": true
+      }
     }
   }
 }

--- a/extension-config.json
+++ b/extension-config.json
@@ -105,7 +105,7 @@
       "destination": "frontend",
       "default": "#fff",
       "params": {
-        "type": "number",
+        "type": "text",
         "label": "Text color of the optional image overlay label"
       }
     },
@@ -124,7 +124,7 @@
       "destination": "frontend",
       "default": null,
       "params": {
-        "label": "Characteristic names which are used as color swatch (e.g.['Color', 'Shoe Color', 'Farbe']",
+        "label": "A list of characteristic names which are used as color swatch (e.g. ['Color', 'Shoe Color', 'Farbe']",
         "type": "json",
         "required": true
       }

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "id": "@shopgate-project/pdp-variant-accordion",
   "components": [
     {
@@ -34,7 +34,7 @@
       "default": false,
       "params": {
         "type": "checkbox",
-        "label": "Wether the characteristics accordions are animated"
+        "label": "Whether the characteristics accordions are animated"
       }
     },
     "characteristicBorderColor": {
@@ -70,7 +70,43 @@
       "default": true,
       "params": {
         "type": "checkbox",
-        "label": "Wether the last characteristic has a border at the bottom"
+        "label": "Whether the last characteristic has a border at the bottom"
+      }
+    },
+    "useImageAsSwatch": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": false,
+      "params": {
+        "type": "checkbox",
+        "label": "Whether the swatch should be shown as an image"
+      }
+    },
+    "showSwatchAsCircle": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": false,
+      "params": {
+        "type": "checkbox",
+        "label": "Whether the swatch is shown as a rectangle or a circle"
+      }
+    },
+    "showLabelBelowSwatch": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": false,
+      "params": {
+        "type": "checkbox",
+        "label": "Whether the label of the swatch is shown below the swatch itself"
+      }
+    },
+    "imageOverlayLabelColor": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": "#fff",
+      "params": {
+        "type": "number",
+        "label": "Text color of the optional image overlay label"
       }
     },
     "propertyWithColor": {

--- a/extension-config.json
+++ b/extension-config.json
@@ -147,6 +147,16 @@
         "type": "text",
         "required": true
       }
+    },
+    "sortColorImageCharacteristic": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": "",
+      "params": {
+        "label": "Sort the Color Image Characteristic. String of the values",
+        "type": "text",
+        "required": true
+      }
     }
   }
 }

--- a/frontend/components/ProductCharacteristics/Provider.jsx
+++ b/frontend/components/ProductCharacteristics/Provider.jsx
@@ -16,10 +16,10 @@ const allowMultipleOpen = false;
 const ProductCharacteristicsProvider = ({
   characteristics,
   colorCharacteristic,
+  colorImageCharacteristic,
   children,
 }) => {
   const [characteristicStates, setCharacteristicStates] = useState(null);
-
   // Initialize the characteristic states
   useEffect(() => {
     if (
@@ -61,7 +61,6 @@ const ProductCharacteristicsProvider = ({
     if (!colorCharacteristic || characteristic.id !== colorCharacteristic.id) {
       return null;
     }
-
     const { color } = colorCharacteristic.values.find(({ id }) => id === value.id) || {};
 
     if (!color) {
@@ -71,12 +70,35 @@ const ProductCharacteristicsProvider = ({
     return color;
   }, [colorCharacteristic]);
 
+  /**
+   * Determines a swatch image that's displayed instead of a characteristic value label or color
+   * @returns {string|null}
+   */
+  const getSwatchImage = useCallback((characteristic, value) => {
+    if (!colorImageCharacteristic || characteristic.id !== colorImageCharacteristic.id) {
+      return null;
+    }
+    const {
+      imageUrl,
+      imageOverlayLabel,
+    } = colorImageCharacteristic.values.find(({ id }) => id === value.id) || {};
+
+    if (!imageUrl) {
+      return null;
+    }
+    return {
+      imageUrl,
+      imageOverlayLabel,
+    };
+  }, [colorImageCharacteristic]);
+
   const value = useMemo(() => ({
     allowMultipleOpen,
     characteristicStates: characteristicStates || [],
     setOpenState,
     getSwatchColor,
-  }), [characteristicStates, getSwatchColor, setOpenState]);
+    getSwatchImage,
+  }), [characteristicStates, getSwatchColor, getSwatchImage, setOpenState]);
 
   return (
     <Context.Provider value={value}>
@@ -89,10 +111,12 @@ ProductCharacteristicsProvider.propTypes = {
   characteristics: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   children: PropTypes.node,
   colorCharacteristic: PropTypes.shape(),
+  colorImageCharacteristic: PropTypes.shape(),
 };
 
 ProductCharacteristicsProvider.defaultProps = {
   colorCharacteristic: null,
+  colorImageCharacteristic: null,
   children: null,
 };
 

--- a/frontend/components/ProductCharacteristics/components/Characteristic/components/CharacteristicValue/index.jsx
+++ b/frontend/components/ProductCharacteristics/components/Characteristic/components/CharacteristicValue/index.jsx
@@ -17,6 +17,8 @@ const {
   showLabelBelowSwatch,
   colorCharacteristic,
   imageOverlayLabelColor,
+  imageSwatchSize,
+  imageSwatchBackgroundSize,
 } = config;
 
 const borderColor = characteristicValueBorderColor || '#DCDCDC';
@@ -65,11 +67,12 @@ const styles = {
   }).toString(),
   imageOverlayLabel: css({
     fontSize: '12px',
-    lineHeight: '50px',
+    lineHeight: `${imageSwatchSize}px`,
     color: imageOverlayLabelColor || '#fff',
   }).toString(),
   labelBelowSwatch: css({
     marginTop: '4px',
+    fontSize: '0.6rem',
   }).toString(),
 };
 
@@ -147,6 +150,9 @@ const CharacteristicValue = ({
               style={{
                 background: swatchColor,
                 backgroundImage: `url(${swatchImage ? swatchImage.imageUrl : ''})`,
+                backgroundSize: imageSwatchBackgroundSize,
+                width: `${imageSwatchSize}px`,
+                height: `${imageSwatchSize}px`,
               }}
             >
               { swatchImage && swatchImage.imageOverlayLabel ? (

--- a/frontend/components/ProductCharacteristics/components/Characteristic/components/CharacteristicValues/index.jsx
+++ b/frontend/components/ProductCharacteristics/components/Characteristic/components/CharacteristicValues/index.jsx
@@ -11,6 +11,7 @@ const { colors } = themeConfig;
 const {
   horizontalInsets,
   animate,
+  sortColorImageCharacteristic,
 } = config;
 
 const insets = horizontalInsets || 0;
@@ -90,6 +91,39 @@ const CharacteristicValues = ({
     }, animationDuration * 2);
   }, [open, values]);
 
+  /**
+   * Get an sort number from value label and sortValues
+   * @param {Object} value Product values object
+   * @param {Array} sortValuesArray Array of labels in the order they should be sorted
+   * @return {number}
+  */
+  const valueToIndex = (value, sortValuesArray) => {
+    const { label } = value || {};
+
+    if (!label) {
+      return sortValuesArray.length;
+    }
+
+    const valueIndex = sortValuesArray.indexOf(label);
+
+    return valueIndex < 0 ? sortValuesArray.length : valueIndex;
+  };
+
+  const sortColorImageCharacteristicArray = sortColorImageCharacteristic
+    .split(',')
+    .filter(sortChar => !!sortChar)
+    .map(sortChar => sortChar.trim());
+
+  const sortedValues = values
+    .filter((value) => {
+      const { label } = value || {};
+      return !!label;
+    })
+    .sort((valueA, valueB) => (
+      // eslint-disable-next-line max-len
+      valueToIndex(valueA, sortColorImageCharacteristicArray) - valueToIndex(valueB, sortColorImageCharacteristicArray)
+    ));
+
   return (
     <div
       className={classNames(styles.root, 'pdp-variant-accordion__characteristic__values', {
@@ -99,7 +133,7 @@ const CharacteristicValues = ({
       <div className={styles.container} ref={containerRef}>
         <div className={classNames(styles.terminator)}>&nbsp;</div>
         <div className={styles.valuesContainer}>
-          { values.map(value => (
+          { sortedValues.map(value => (
             <CharacteristicValue
               key={value.id}
               characteristicId={characteristicId}

--- a/frontend/components/ProductCharacteristics/connector.js
+++ b/frontend/components/ProductCharacteristics/connector.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import { getProductVariants } from '@shopgate/engage/product';
-import { getColorCharacteristic } from '../../selectors';
+import { getColorCharacteristic, getColorImageCharacteristic } from '../../selectors';
 
 /**
  * Maps the contents of the state to the component props.
@@ -14,6 +14,7 @@ const mapStateToProps = (state, props) => {
   return {
     characteristics: variants ? variants.characteristics : [],
     colorCharacteristic: getColorCharacteristic(state, props),
+    colorImageCharacteristic: getColorImageCharacteristic(state, props),
   };
 };
 

--- a/frontend/constants/index.js
+++ b/frontend/constants/index.js
@@ -1,3 +1,3 @@
-export const IMAGE_URL_LABEL = 'imageUrl';
+export const IMAGE_URL = 'imageUrl';
 export const IMAGE_OVERLAY_LABEL = 'imageOverlayLabel';
 export const SWATCH_IMAGE_PREFIX = 'swatchImage~';

--- a/frontend/constants/index.js
+++ b/frontend/constants/index.js
@@ -1,0 +1,3 @@
+export const IMAGE_URL_LABEL = 'imageUrl';
+export const IMAGE_OVERLAY_LABEL = 'imageOverlayLabel';
+export const SWATCH_IMAGE_PREFIX = 'swatchImage~';

--- a/frontend/selectors/index.js
+++ b/frontend/selectors/index.js
@@ -1,7 +1,8 @@
 import { createSelector } from 'reselect';
 import { getProductVariants } from '@shopgate/engage/product';
 import { isDev } from '@shopgate/engage/core';
-import { colorCharacteristic, propertyWithColor } from '../config';
+import { colorCharacteristic, propertyWithColor, useImageAsSwatch } from '../config';
+import { IMAGE_OVERLAY_LABEL, IMAGE_URL_LABEL, SWATCH_IMAGE_PREFIX } from '../constants';
 
 export const getColorCharacteristic = createSelector(
   getProductVariants,
@@ -23,7 +24,6 @@ export const getColorCharacteristic = createSelector(
       const { additionalProperties } = variants.products.find(p => (
         p.characteristics[characteristic.id] === value.id
       )) || {};
-
       let property;
 
       if (additionalProperties) {
@@ -46,6 +46,65 @@ export const getColorCharacteristic = createSelector(
       return {
         ...value,
         color: property ? property.value : null,
+      };
+    }).filter(Boolean);
+
+    return {
+      ...characteristic,
+      values: updateValues,
+    };
+  }
+);
+
+export const getColorImageCharacteristic = createSelector(
+  getProductVariants,
+  (variants) => {
+    if (!variants || !Array.isArray(colorCharacteristic) || !useImageAsSwatch) {
+      return null;
+    }
+
+    const characteristic = variants.characteristics.find(char => (
+      colorCharacteristic.includes(char.label)
+    ));
+
+    if (!characteristic) {
+      return null;
+    }
+
+    const updateValues = characteristic.values.map((value) => {
+      const { additionalProperties } = variants.products.find(p => (
+        p.characteristics[characteristic.id] === value.id
+      )) || {};
+      let property;
+      let imageUrl;
+      let imageOverlayLabel = null;
+
+      if (additionalProperties) {
+        property = additionalProperties.find(p => p.label.toUpperCase() === `${SWATCH_IMAGE_PREFIX}${value.label}`.toUpperCase());
+
+        if (!property) {
+          imageUrl = null;
+          imageOverlayLabel = null;
+        } else {
+          const values = property.value.split(',').map(vp => vp.trim());
+          values.forEach((v) => {
+            const valueParts = v.split('~');
+            const propLabel = valueParts[0];
+            const propValue = valueParts[1];
+            if (propLabel === IMAGE_URL_LABEL) {
+              imageUrl = propValue;
+            }
+            if (propLabel === IMAGE_OVERLAY_LABEL) {
+              imageOverlayLabel = propValue;
+            }
+          });
+        }
+      }
+
+      return {
+        ...value,
+        imageUrl,
+        imageOverlayLabel,
       };
     }).filter(Boolean);
 

--- a/frontend/selectors/index.js
+++ b/frontend/selectors/index.js
@@ -2,7 +2,7 @@ import { createSelector } from 'reselect';
 import { getProductVariants } from '@shopgate/engage/product';
 import { isDev } from '@shopgate/engage/core';
 import { colorCharacteristic, propertyWithColor, useImageAsSwatch } from '../config';
-import { IMAGE_OVERLAY_LABEL, IMAGE_URL_LABEL, SWATCH_IMAGE_PREFIX } from '../constants';
+import { IMAGE_OVERLAY_LABEL, IMAGE_URL, SWATCH_IMAGE_PREFIX } from '../constants';
 
 export const getColorCharacteristic = createSelector(
   getProductVariants,
@@ -91,7 +91,7 @@ export const getColorImageCharacteristic = createSelector(
             const valueParts = v.split('~');
             const propLabel = valueParts[0];
             const propValue = valueParts[1];
-            if (propLabel === IMAGE_URL_LABEL) {
+            if (propLabel === IMAGE_URL) {
               imageUrl = propValue;
             }
             if (propLabel === IMAGE_OVERLAY_LABEL) {


### PR DESCRIPTION
To test this you need the extension @shopgate-project/products-properties @ 1.1.0 to be able to add properties with a prefix before the property name itself.