### PR TITLE
Add placeholder while variant data is fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.6.0
+### Added
+- Added placeholder that's visible till variant data is fetched. Can be configured via `placeholderLines` setting. When set to `0` the placeholder will never be shown.
+
 ## 1.5.1 - 2025-06-05
 ### Fixed
 - Fixed an issue that allowed horizontal scrolling on PDP beyond the screen’s width limit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 1.6.0
+## 1.6.0 - 2025-07-17
 ### Added
 - Added placeholder that's visible till variant data is fetched. Can be configured via `placeholderLines` setting. When set to `0` the placeholder will never be shown.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It also supports color and image swatches via additional product properties, pro
 ![](assets/02.png)
 
 ## Config
+- `placeholderLines` (number) Number of placeholder lines shown while product variants are fetching. When set to 0 placeholder is deactivated. (default `3`)
 - `horizontalInsets` (number) Horizontal insets for the characteristics in pixels (e.g. 16)
 - `bottomInset` (number) Trailing inset for the characteristics block in pixels (e.g. 16)
 - `animate` (boolean) Whether the characteristics accordions are supposed to be animated (_default_ `false`)

--- a/README.md
+++ b/README.md
@@ -50,11 +50,27 @@ It also supports color and image swatches via additional product properties, pro
 
 The extension adds the following classes to its components to enable extended styling from other extensions:
 
-- `pdp-variant-accordion` Applied to the wrapper of the characteristics block
-- `pdp-variant-accordion__characteristic` Applied to each characteristic section
-- `pdp-variant-accordion__characteristic.disabled` Applied to a _disabled_ characteristic section
-- `pdp-variant-accordion__characteristic__header` Applied to the header of a characteristic section
-- `pdp-variant-accordion__characteristic__values` Applied to the values wrapper of a characteristic section
-- `pdp-variant-accordion__characteristic__value` Applied to each characteristic value
-- `pdp-variant-accordion__characteristic__value.selected` Applied to the _selected_ characteristic value
-- `pdp-variant-accordion__characteristic__value.disabled` Applied to a _disabled_ characteristic value
+- `.pdp-variant-accordion` Applied to the wrapper of the characteristics block
+- `.pdp-variant-accordion__characteristic` Applied to each characteristic section
+- `.pdp-variant-accordion__characteristic.disabled` Applied to a _disabled_ characteristic section
+- `.pdp-variant-accordion__characteristic__header` Applied to the header of a characteristic section
+- `.pdp-variant-accordion__characteristic__values` Applied to the values wrapper of a characteristic section
+- `.pdp-variant-accordion__characteristic__value` Applied to each characteristic value
+- `.pdp-variant-accordion__characteristic__value.selected` Applied to the _selected_ characteristic value
+- `.pdp-variant-accordion__characteristic__value.disabled` Applied to a _disabled_ characteristic value
+- `.pdp-variant-accordion .ui-shared__placeholder-paragraph` Can be used to style the container with the fetching placeholder bars
+- `.pdp-variant-accordion .ui-shared__placeholder-paragraph .ui-shared__placeholder-label` Can be used to style one of the fetching placeholder bars
+
+## Simulate fetching placeholder
+Styling the fetching placeholder can be tricky, especially because it’s ideally only visible for a brief moment during normal use. To assist with development and testing, you can manually simulate the fetching state using the browser console.
+
+To activate the fetching state for the currently visible Product Detail Page (PDP), run the following command in the browser’s JavaScript console:
+
+```js
+window.pdpVariantAccordionSimulateFetching(true)
+```
+
+Once you’re done, you can deactivate the fetching state by running:
+```js
+window.pdpVariantAccordionSimulateFetching(false)
+```

--- a/extension-config.json
+++ b/extension-config.json
@@ -188,6 +188,17 @@
         "type": "json",
         "required": true
       }
+    },
+    "placeholderLines": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": 3,
+      "params": {
+        "label": "Placeholder lines",
+        "description": "Number of lines to show in the placeholder",
+        "type": "number",
+        "required": true
+      }
     }
   }
 }

--- a/frontend/components/ProductCharacteristics/Provider.jsx
+++ b/frontend/components/ProductCharacteristics/Provider.jsx
@@ -16,6 +16,7 @@ const { variantSelectionAlwaysOpen } = config;
  * @returns {JSX}
  */
 const ProductCharacteristicsProvider = ({
+  isFetching,
   characteristics,
   products,
   colorCharacteristic,
@@ -100,13 +101,21 @@ const ProductCharacteristicsProvider = ({
   }, [colorImageCharacteristic]);
 
   const value = useMemo(() => ({
+    isFetching,
     allowMultipleOpen,
     productVariants,
     characteristicStates: characteristicStates || [],
     setOpenState,
     getSwatchColor,
     getSwatchImage,
-  }), [productVariants, characteristicStates, getSwatchColor, getSwatchImage, setOpenState]);
+  }), [
+    isFetching,
+    productVariants,
+    characteristicStates,
+    getSwatchColor,
+    getSwatchImage,
+    setOpenState,
+  ]);
 
   return (
     <Context.Provider value={value}>
@@ -117,6 +126,7 @@ const ProductCharacteristicsProvider = ({
 
 ProductCharacteristicsProvider.propTypes = {
   characteristics: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+  isFetching: PropTypes.bool.isRequired,
   children: PropTypes.node,
   colorCharacteristic: PropTypes.shape(),
   colorImageCharacteristic: PropTypes.shape(),

--- a/frontend/components/ProductCharacteristics/connector.js
+++ b/frontend/components/ProductCharacteristics/connector.js
@@ -1,6 +1,9 @@
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
-import { getProductVariants } from '@shopgate/engage/product';
+import {
+  getProductVariants,
+  hasProductVariants,
+} from '@shopgate/engage/product';
 import { getColorCharacteristic, getColorImageCharacteristic } from '../../selectors';
 
 /**
@@ -11,6 +14,7 @@ import { getColorCharacteristic, getColorImageCharacteristic } from '../../selec
  */
 const mapStateToProps = (state, props) => {
   const variants = getProductVariants(state, props);
+  const hasVariants = hasProductVariants(state, props);
 
   // Check if base product has only a single characteristic (required be able to show prices)
   const hasSingleCharacteristic =
@@ -19,6 +23,7 @@ const mapStateToProps = (state, props) => {
     variants.characteristics.length === 1;
 
   return {
+    isFetching: !!hasVariants && !variants,
     products: hasSingleCharacteristic ? variants.products : null,
     characteristics: variants ? variants.characteristics : [],
     colorCharacteristic: getColorCharacteristic(state, props),

--- a/frontend/components/ProductCharacteristics/index.jsx
+++ b/frontend/components/ProductCharacteristics/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import { css } from 'glamor';
 import classNames from 'classnames';
 import {
@@ -40,6 +40,14 @@ const ProductCharacteristics = () => {
     conditioner,
   } = useCurrentProduct();
 
+  const [simulateFetching, setSimulateFetching] = useState(false);
+
+  useEffect(() => {
+    window.pdpVariantAccordionSimulateFetching = (simulate = true) => {
+      setSimulateFetching(simulate);
+    };
+  }, []);
+
   const renderCharacteristic = useCallback(
     renderProps => (<Characteristic {...renderProps} />),
     []
@@ -51,7 +59,7 @@ const ProductCharacteristics = () => {
         <Context.Consumer>
           {({ isFetching }) => (
             <PlaceholderParagraph
-              ready={!isFetching}
+              ready={!simulateFetching && !isFetching}
               lines={placeholderLines}
               className={styles.placeholder}
             >

--- a/frontend/components/ProductCharacteristics/index.jsx
+++ b/frontend/components/ProductCharacteristics/index.jsx
@@ -42,6 +42,10 @@ const ProductCharacteristics = () => {
 
   const [simulateFetching, setSimulateFetching] = useState(false);
 
+  /**
+   * Effect to set up a global function that allows to simulate the fetching state.
+   * Can be useful when placeholder styling is supposed to be adjusted.
+   */
   useEffect(() => {
     window.pdpVariantAccordionSimulateFetching = (simulate = true) => {
       setSimulateFetching(simulate);

--- a/frontend/components/ProductCharacteristics/index.jsx
+++ b/frontend/components/ProductCharacteristics/index.jsx
@@ -5,12 +5,13 @@ import {
   ProductCharacteristics as EngageProductCharacteristics,
 } from '@shopgate/engage/product';
 import { useCurrentProduct } from '@shopgate/engage/core';
+import { PlaceholderParagraph } from '@shopgate/engage/components';
 import Characteristic from './components/Characteristic';
-import ProductCharacteristicsProvider from './Provider';
+import ProductCharacteristicsProvider, { Context } from './Provider';
 
 import config from '../../config';
 
-const { bottomInset = 0 } = config;
+const { bottomInset = 0, placeholderLines = 3 } = config;
 
 const styles = {
   root: css({
@@ -18,6 +19,12 @@ const styles = {
     ':empty': {
       display: 'none',
     },
+    '& .ui-shared__placeholder-paragraph': css({
+      padding: 16,
+    }),
+  }).toString(),
+  placeholder: css({
+    height: '0.875rem',
   }).toString(),
 };
 
@@ -41,14 +48,26 @@ const ProductCharacteristics = () => {
   return (
     <div className={classNames(styles.root, 'pdp-variant-accordion')}>
       <ProductCharacteristicsProvider productId={productId} variantId={variantId}>
-        <EngageProductCharacteristics
-          productId={productId}
-          variantId={variantId}
-          conditioner={conditioner}
-          setCharacteristics={setCharacteristics}
-          finishTimeout={200}
-          render={renderCharacteristic}
-        />
+        <Context.Consumer>
+          {({ isFetching }) => (
+            <PlaceholderParagraph
+              ready={!isFetching}
+              lines={placeholderLines}
+              className={styles.placeholder}
+            >
+              <EngageProductCharacteristics
+                productId={productId}
+                variantId={variantId}
+                conditioner={conditioner}
+                setCharacteristics={setCharacteristics}
+                finishTimeout={200}
+                render={renderCharacteristic}
+              />
+
+            </PlaceholderParagraph>
+          )}
+        </Context.Consumer>
+
       </ProductCharacteristicsProvider>
     </div>
   );

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,23 +11,9 @@
     "@shopgate/eslint-config": "^6.18.7-beta.3",
     "@shopgate/pwa-common": "^6.18.7-beta.3",
     "@shopgate/engage": "^6.18.7-beta.3",
-    "babel-core": "^6.26.0",
-    "babel-plugin-react-transform": "^3.0.0",
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-export-extensions": "^6.22.0",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-plugin-transform-react-inline-elements": "^6.22.0",
-    "babel-plugin-transform-react-jsx": "^6.24.1",
-    "babel-preset-env": "^1.6.1",
-    "babel-preset-react": "^6.24.1",
     "eslint": "^5.12.0",
     "glamor": "^2.20.40",
     "prop-types": "^15.6.0",
-    "react": "~16.8.4",
-    "react-dom": "~16.8.4",
-    "react-helmet": "^5.2.0",
-    "react-transition-group": "^2.2.1",
-    "react-hot-loader": "^3.1.3",
-    "react-transform-catch-errors": "^1.0.2"
+    "react": "~16.8.4"
   }
 }


### PR DESCRIPTION
This pull request adds a placeholder that's visible while variant data is fetching. The `placeholderLines` config parameter can be used to configure the amount of lines shown during loading. When set to 0, the placeholder will never be visible.